### PR TITLE
Propagator evolution. Change in interface.

### DIFF
--- a/src/propmachinery.jl
+++ b/src/propmachinery.jl
@@ -1,7 +1,7 @@
 abstract QuPropagatorMethod
 
 @doc """
-QuPropagator Type
+QuPropagator and QuStateEvolution types are the same.
 
 The central piece which dispatches to various solvers. The various outer constructions, allow to
 give in various inputs. For example if the Hamiltonian is `QuBase.AbstractQuMatrix` and the  initial state
@@ -27,27 +27,30 @@ Inputs :
 Output :
 * QuPropagator construct depending on the input.
 """ ->
-immutable QuPropagator{QPM<:QuPropagatorMethod, QVM<:Union(QuBase.AbstractQuVector,QuBase.AbstractQuMatrix), QE<:QuEquation}
+immutable QuStateEvolution{QPM<:QuPropagatorMethod, QVM<:@compat(Union{QuBase.AbstractQuVector,QuBase.AbstractQuMatrix}), QE<:QuEquation}
     eq::QE
     init_state::QVM
     tlist
     method::QPM
-    QuPropagator(eq, init_state, tlist, method) = new(eq, init_state, tlist, method)
+    QuStateEvolution(eq, init_state, tlist, method) = new(eq, init_state, tlist, method)
 end
 
-QuPropagator{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector}(eq::QuSchrodingerEq, init_state::QV, tlist, method::QPM) = QuPropagator{QPM,QV,QuSchrodingerEq}(eq, init_state, tlist, method)
+QuStateEvolution{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector}(eq::QuSchrodingerEq, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QuSchrodingerEq}(eq, init_state, tlist, method)
 
-QuPropagator{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector}(hamiltonian::QuBase.AbstractQuMatrix, init_state::QV,  tlist, method::QPM) = QuPropagator{QPM,QV,QuSchrodingerEq}(QuSchrodingerEq(hamiltonian),init_state, tlist, method)
+QuStateEvolution{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector}(hamiltonian::QuBase.AbstractQuMatrix, init_state::QV,  tlist, method::QPM) = QuStateEvolution{QPM,QV,QuSchrodingerEq}(QuSchrodingerEq(hamiltonian),init_state, tlist, method)
 
-QuPropagator{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix}(eq::QuLiouvillevonNeumannEq, init_state::QM, tlist, method::QPM) = QuPropagator{QPM,QM,QuLiouvillevonNeumannEq}(eq, init_state, tlist, method)
+QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix}(eq::QuLiouvillevonNeumannEq, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLiouvillevonNeumannEq}(eq, init_state, tlist, method)
 
-QuPropagator{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix}(hamiltonian::QuBase.AbstractQuMatrix, init_state::QM,  tlist, method::QPM) = QuPropagator{QPM,QM,QuLiouvillevonNeumannEq}(QuLiouvillevonNeumannEq(liouvillian_op(hamiltonian)),init_state, tlist, method)
+QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix}(hamiltonian::QuBase.AbstractQuMatrix, init_state::QM,  tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLiouvillevonNeumannEq}(QuLiouvillevonNeumannEq(liouvillian_op(hamiltonian)),init_state, tlist, method)
 
-QuPropagator{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix}(eq::QuLindbladMasterEq, init_state::QM, tlist, method::QPM) = QuPropagator{QPM,QM,QuLindbladMasterEq}(eq, init_state, tlist, method)
+QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix}(eq::QuLindbladMasterEq, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLindbladMasterEq}(eq, init_state, tlist, method)
 
-QuPropagator{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix, COT<:QuBase.AbstractQuMatrix}(hamiltonian::QuBase.AbstractQuMatrix, collapse_ops::Vector{COT}, init_state::QM, tlist, method::QPM) = QuPropagator{QPM,QM,QuLindbladMasterEq}(QuLindbladMasterEq(hamiltonian,collapse_ops), init_state, tlist, method)
+QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix, COT<:QuBase.AbstractQuMatrix}(hamiltonian::QuBase.AbstractQuMatrix, collapse_ops::Vector{COT}, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLindbladMasterEq}(QuLindbladMasterEq(hamiltonian,collapse_ops), init_state, tlist, method)
 
-QuPropagator{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector, COT<:QuBase.AbstractQuMatrix}(hamiltonian::QuBase.AbstractQuMatrix, collapse_ops::Vector{COT}, init_state::QV, tlist, method::QPM) = QuPropagator{QPM,QV,QuLindbladMasterEq}(QuLindbladMasterEq(hamiltonian,collapse_ops), init_state, tlist, method)
+QuStateEvolution{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector, COT<:QuBase.AbstractQuMatrix}(hamiltonian::QuBase.AbstractQuMatrix, collapse_ops::Vector{COT}, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QuLindbladMasterEq}(QuLindbladMasterEq(hamiltonian,collapse_ops), init_state, tlist, method)
+
+# QuPropagator and QuStateEvolution types are the same.
+typealias QuPropagator QuStateEvolution
 
 @doc """
 QuPropagator State
@@ -71,7 +74,7 @@ Output :
 * QuPropagatorState construct.
 """ ->
 immutable QuPropagatorState
-    psi
+    state
     t
     t_state
 end
@@ -91,7 +94,7 @@ Inputs :
 Output :
 * QuPropagatorState construct with parameters as initial state, start time and time state.
 """ ->
-function Base.start(prob::QuPropagator)
+function Base.start(prob::QuStateEvolution)
     init_state = prob.init_state
     t_state = start(prob.tlist)
     t,t_state = next(prob.tlist,t_state)
@@ -109,7 +112,6 @@ Inputs :
 * prob :: QuPropagator{QuPropagatorMethod}
 
   The  `QuPropagator` contruct which involves the parameters of the system.
-
 * qustate :: QuPropagatorState
 
   Current QuPropagatorState
@@ -117,8 +119,8 @@ Inputs :
 Output :
 * Next state, Time corresponding to the current time and related QuPropagatorState
 """ ->
-function Base.next{QPM<:QuPropagatorMethod}(prob::QuPropagator{QPM}, qustate::QuPropagatorState)
-    current_qustate = qustate.psi
+function Base.next{QPM<:QuPropagatorMethod}(prob::QuStateEvolution{QPM}, qustate::QuPropagatorState)
+    current_qustate = qustate.state
     current_t = qustate.t
     t,t_state = next(prob.tlist, qustate.t_state)
     next_qustate = propagate(prob.method, prob.eq, t, current_t, current_qustate)
@@ -128,7 +130,7 @@ end
 @doc """
 Iterator for QuPropagator
 
-Iterator `next` method for QuPropagator
+Iterator `done` method for QuPropagator
 
 ### Arguments
 
@@ -140,7 +142,37 @@ Inputs :
 Output :
 * True if the current state is final state, else false.
 """ ->
-Base.done(prob::QuPropagator, qustate::QuPropagatorState) = done(prob.tlist, qustate.t_state)
+Base.done(prob::QuStateEvolution, qustate::QuPropagatorState) = done(prob.tlist, qustate.t_state)
 
-export  QuPropagator,
+@doc """
+Propagation of the time evolution operator.
+
+### Arguments
+
+Inputs :
+* op <: QuBase.AbstractQuMatrix
+
+  Operator to be evolved.
+* dt :: Float64
+
+  Time step.
+
+* tf, ti :: Float64
+
+  Final Time, Initial Time.
+
+Output :
+* Evolved operator.
+""" ->
+QuEvolutionOp{QM<:QuBase.AbstractQuMatrix}(op::QM, dt::Float64) = expm(-im*op*dt)
+
+QuEvolutionOp{QM<:QuBase.AbstractQuMatrix}(op::QM, tf::Float64,  ti::Float64) = QuEvolutionOp(op, tf-ti)
+
+QuEvolutionOp{QE<:QuEquation}(eq::QE, dt::Float64) = QuEvolutionOp(operator(eq), dt)
+
+QuEvolutionOp{QE<:QuEquation}(eq::QE, tf::Float64, ti::Float64) = QuEvolutionOp(eq, tf-ti)
+
+export  QuStateEvolution,
+      QuPropagator,
+      QuEvolutionOp,
       QuPropagatorState

--- a/test/propagatortest.jl
+++ b/test/propagatortest.jl
@@ -15,7 +15,7 @@ const solver = @compat Dict{Any, Any}(:qu_euler => QuEuler, :qu_cn => QuCrankNic
 
 for (key,value) in solver
     @eval begin
-        $key = QuPropagator(hamiltonian, init_state, tlist, $value())
+        $key = QuStateEvolution(hamiltonian, init_state, tlist, $value())
     end
 end
 
@@ -43,18 +43,18 @@ next_state_actual = expm(-im*sigmax*0.1)*init_state
 
 lvn = QuLiouvillevonNeumannEq(QuDynamics.liouvillian_op(sigmax))
 
-qexpokit_lvn = QuPropagator(lvn, init_state*init_state', tlist, QuExpokit())
-qexpokit_dm = QuPropagator(sigmax, init_state*init_state', tlist, QuExpokit())
+qexpokit_lvn = QuStateEvolution(lvn, init_state*init_state', tlist, QuExpokit())
+qexpokit_dm = QuStateEvolution(sigmax, init_state*init_state', tlist, QuExpokit())
 next_state_qexpokit_lvn = next(qexpokit_lvn, start(qexpokit_lvn))
 next_state_qexpokit_dm = next(qexpokit_dm, start(qexpokit_dm))
 @assert next_state_qexpokit_lvn[1][2] == next_state_qexpokit_dm[1][2]
-qode45_lvn = QuPropagator(lvn, init_state*init_state', tlist, QuODE45())
-qode45_dm = QuPropagator(sigmax, init_state*init_state', tlist, QuODE45())
+qode45_lvn = QuStateEvolution(lvn, init_state*init_state', tlist, QuODE45())
+qode45_dm = QuStateEvolution(sigmax, init_state*init_state', tlist, QuODE45())
 next_state_qode45_lvn = next(qode45_lvn, start(qode45_lvn))
 next_state_qode45_dm = next(qode45_dm, start(qode45_dm))
 @assert next_state_qode45_lvn[1][2] == next_state_qode45_dm[1][2]
-qeuler_lvn = QuPropagator(lvn, init_state*init_state', tlist, QuEuler())
-qeuler_dm = QuPropagator(sigmax, init_state*init_state', tlist, QuEuler())
+qeuler_lvn = QuStateEvolution(lvn, init_state*init_state', tlist, QuEuler())
+qeuler_dm = QuStateEvolution(sigmax, init_state*init_state', tlist, QuEuler())
 next_state_qeuler_lvn = next(qeuler_lvn, start(qeuler_lvn))
 next_state_qeuler_dm = next(qeuler_dm, start(qeuler_dm))
 @assert next_state_qeuler_lvn[1][2] == next_state_qeuler_dm[1][2]
@@ -71,18 +71,18 @@ next_state_actual = expm(-im*QuDynamics.liouvillian_op(sigmax)*0.1)*vec(init_sta
 c_ops = [lowerop(2)]
 lmeq = QuLindbladMasterEq(sigmax, c_ops)
 
-qexpokit_lmeq = QuPropagator(lmeq, init_state*init_state', tlist, QuExpokit())
-qexpokit_dm = QuPropagator(sigmax, c_ops, init_state*init_state', tlist, QuExpokit())
+qexpokit_lmeq = QuStateEvolution(lmeq, init_state*init_state', tlist, QuExpokit())
+qexpokit_dm = QuStateEvolution(sigmax, c_ops, init_state*init_state', tlist, QuExpokit())
 next_state_qexpokit_lmeq = next(qexpokit_lmeq, start(qexpokit_lmeq))
 next_state_qexpokit_dm = next(qexpokit_dm, start(qexpokit_dm))
 @assert next_state_qexpokit_lmeq[1][2] == next_state_qexpokit_dm[1][2]
-qode78_lmeq = QuPropagator(lmeq, init_state*init_state', tlist, QuODE78())
-qode78_dm = QuPropagator(sigmax, c_ops, init_state*init_state', tlist, QuODE78())
+qode78_lmeq = QuStateEvolution(lmeq, init_state*init_state', tlist, QuODE78())
+qode78_dm = QuStateEvolution(sigmax, c_ops, init_state*init_state', tlist, QuODE78())
 next_state_qode78_lmeq = next(qode78_lmeq, start(qode78_lmeq))
 next_state_qode78_dm = next(qode78_dm, start(qode78_dm))
 @assert next_state_qode78_lmeq[1][2] == next_state_qode78_dm[1][2]
-qcn_lmeq = QuPropagator(lmeq, init_state*init_state', tlist, QuCrankNicolson())
-qcn_dm = QuPropagator(sigmax, c_ops, init_state*init_state', tlist, QuCrankNicolson())
+qcn_lmeq = QuStateEvolution(lmeq, init_state*init_state', tlist, QuCrankNicolson())
+qcn_dm = QuStateEvolution(sigmax, c_ops, init_state*init_state', tlist, QuCrankNicolson())
 next_state_qcn_lmeq = next(qcn_lmeq, start(qcn_lmeq))
 next_state_qcn_dm = next(qcn_dm, start(qcn_dm))
 @assert next_state_qcn_lmeq[1][2] == next_state_qcn_dm[1][2]
@@ -112,13 +112,13 @@ end
 for psi0 in qumcwfen
     i = 1
     mcwf = QuMCWF()
-    for (t,psi) in QuPropagator(hamiltonian, c_ops, psi0, tlist, mcwf)
+    for (t,psi) in QuStateEvolution(hamiltonian, c_ops, psi0, tlist, mcwf)
         rhos[i] = rhos[i] + (psi*psi')/length(qumcwfen)/norm(psi)^2
         i = i + 1
     end
 end
 
-prop_expm = QuPropagator(hamiltonian, c_ops, rho, tlist, QuExpmV())
+prop_expm = QuStateEvolution(hamiltonian, c_ops, rho, tlist, QuExpmV())
 j = 1
 for (t, rhot) in prop_expm
     ps[j] = rhot
@@ -127,3 +127,9 @@ end
 
 ind = findin(tlist, rand(tlist))[1]
 @test_approx_eq_eps coeffs(vec(rhos[ind])) coeffs(vec(ps[ind])) 1e-1
+
+# tests for  evolution opeator.
+evolved_state = coeffs(propagate(QuExpokit(), QuSchrodingerEq(hamiltonian), tlist[2], tlist[1], init_state))
+@test_approx_eq coeffs(QuEvolutionOp(sigmax, 0.1)*init_state) evolved_state
+@test_approx_eq coeffs(QuEvolutionOp(sigmax, tlist[5], tlist[4])*init_state) evolved_state
+@test_approx_eq coeffs(QuEvolutionOp(QuSchrodingerEq(sigmax), tlist[5], tlist[4])*init_state) evolved_state


### PR DESCRIPTION
`QuPropagator` is mapped to `QuStateEvolution`. `QuPropagatorState` is used for both `QuStateEvolution` and `QuPropagatorEvolution`. This aims to address the issue #29 .
