### PR TITLE
Condition for creating QuStateEvolution.

### DIFF
--- a/src/propmachinery.jl
+++ b/src/propmachinery.jl
@@ -32,7 +32,13 @@ immutable QuStateEvolution{QPM<:QuPropagatorMethod, QVM<:@compat(Union{QuBase.Ab
     init_state::QVM
     tlist
     method::QPM
-    QuStateEvolution(eq, init_state, tlist, method) = new(eq, init_state, tlist, method)
+    function QuStateEvolution(eq, init_state, tlist, method)
+        if size(eq)[1]^2 == size(vec(init_state), 1) ||  size(eq)[1] == size(vec(init_state), 1)
+            new(eq, init_state, tlist, method)
+        else
+            error("Operator(Hamiltonian related) and initial state incompatible")
+        end
+    end
 end
 
 QuStateEvolution{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector}(eq::QuSchrodingerEq, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QuSchrodingerEq}(eq, init_state, tlist, method)

--- a/src/quequations.jl
+++ b/src/quequations.jl
@@ -1,4 +1,4 @@
-import Base: ndims
+import Base: size
 
 abstract QuEquation
 
@@ -242,9 +242,9 @@ function eff_hamiltonian(lme::QuLindbladMasterEq)
     return heff
 end
 
-Base.ndims(eq::QuSchrodingerEq) = ndims(eq.hamiltonian)
-Base.ndims(eq::QuLiouvillevonNeumannEq) = ndims(eq.liouvillian)
-Base.ndims(eq::QuLindbladMasterEq) = ndims(eq.lindblad)
+Base.size(eq::QuSchrodingerEq) = size(eq.hamiltonian)
+Base.size(eq::QuLiouvillevonNeumannEq) = size(eq.liouvillian)
+Base.size(eq::QuLindbladMasterEq) = size(eq.lindblad)
 
 export QuEquation,
       QuSchrodingerEq,

--- a/src/quequations.jl
+++ b/src/quequations.jl
@@ -1,3 +1,5 @@
+import Base: ndims
+
 abstract QuEquation
 
 @doc """
@@ -239,6 +241,10 @@ function eff_hamiltonian(lme::QuLindbladMasterEq)
     end
     return heff
 end
+
+Base.ndims(eq::QuSchrodingerEq) = ndims(eq.hamiltonian)
+Base.ndims(eq::QuLiouvillevonNeumannEq) = ndims(eq.liouvillian)
+Base.ndims(eq::QuLindbladMasterEq) = ndims(eq.lindblad)
 
 export QuEquation,
       QuSchrodingerEq,


### PR DESCRIPTION
Currently there is no relation between the `eq` and `init_state`, we should not be able to create something on these lines 

``` julia
julia> QuStateEvolution(sigmax, statevec(1, FiniteBasis(3)), 0.:0.1:2*π, QuODE78())
```

as here the dimension of hamiltonian, here sigmax and dimension of initial state vector do not match. So this should give an error and the current PR aims at this. 
