### PR TITLE
RFC : Attempt at caching the lindblad operator construct, WIP : Docs

### DIFF
--- a/perf/Jaynes_Cummings_MCWF.jl
+++ b/perf/Jaynes_Cummings_MCWF.jl
@@ -1,0 +1,115 @@
+using QuBase
+using QuDynamics
+using BenchmarkLite
+
+type SampleProc{Alg} <: Proc end
+
+# Jaynes-Cummings type which takes the configuration parameters.
+# These parameters are used for benchmarking, creating various
+# JaynesCummings types with various parameters and using
+# the solvers to get the timing results.
+type JaynesCummings
+    N::Int
+    wc::Float64
+    wa::Float64
+    g::Float64
+    kappa::Float64
+    gamma::Float64
+    use_rwa::Bool
+    ntraj
+    tlist
+end
+
+# Name of the solver, used in the creating the table of timing analysis
+Base.string{Alg}(::SampleProc{Alg}) = lowercase(string(Alg))
+
+# Constructing a valid configuration, this is set to `true` as we have
+# set the type of the required fields in the construct `JaynesCummings` itself.
+Base.isvalid{Alg}(p::SampleProc{Alg}, cfg::JaynesCummings) = true
+
+# This returns the `hamitlonian`, `collapse operators`, `state drawn from QuMCWFEnsemble`,
+# `array initialized for storing the evolved states` taking in the `cfg`
+# configuration of the system.
+function operator_set(p::SampleProc, cfg::JaynesCummings)
+    idc = QuArray(eye(cfg.N))
+    ida = QuArray(eye(2))
+    a  = tensor(lowerop(cfg.N), ida)
+    sm = tensor(idc, lowerop(2))
+    if cfg.use_rwa
+        H = cfg.wc * a' * a + cfg.wa * sm' * sm + cfg.g * (a' * sm + a * sm')
+    else
+        H = cfg.wc * a' * a + cfg.wa * sm' * sm + cfg.g * (a' + a) * (sm + sm')
+    end
+    c_op_list = Array(QuBase.AbstractQuMatrix, 0)
+    n_th_a = 0.0
+    rate_1 = cfg.kappa * (1 + n_th_a)
+    if rate_1 > 0.0
+        push!(c_op_list, full(sqrt(rate_1) * a))
+    end
+    rate = cfg.kappa * n_th_a
+    if rate > 0.0
+        push!(c_op_list, full(sqrt(rate) * a'))
+    end
+    rate = cfg.gamma
+    if rate > 0.0
+        push!(c_op_list, full(sqrt(rate) * sm))
+    end
+    psi = complex(tensor(statevec(1, FiniteBasis(cfg.N)), statevec(2, FiniteBasis(2))))
+    rho = psi*psi'
+    qumcwfen = QuMCWFEnsemble(complex(psi), cfg.ntraj)
+    rhos = Array(typeof(rho), length(cfg.tlist)-1)
+    for i=1:length(cfg.tlist)-1
+        rhos[i] = complex(zeros(rho))
+    end
+    return full(H), c_op_list, qumcwfen, rhos
+end
+
+# Start states are pre-allocated, that is they are constructed before the evaluation
+# here we return the `hamiltonian`, `collapse operator list`, `initial density matrix`,
+# `observable whose expectation is to be calculated` using the above function
+# i.e., operator_set. The first three remain fixed, the fourth can be varied as required.
+Base.start(p::SampleProc, cfg::JaynesCummings) = (operator_set(p, cfg))
+
+Base.length(p::SampleProc, cfg::JaynesCummings) = cfg.N
+
+# This function gets the timing done for calculation of trace, using the pre-allocated
+# constructions from the start method i.e., the hamiltonain, collapse operator list,
+# initial density matrix and observable whose expectation is to be calculated.
+function Base.run{Alg}(p::SampleProc{Alg}, cfg::JaynesCummings, s::(QuBase.QuArray, Array, QuDynamics.QuMCWFEnsemble, Array))
+    for psi0 in s[3]
+        i = 1
+        for (t,psi) in QuPropagator(s[1], s[2], psi0, cfg.tlist, Alg())
+            s[4][i] = s[4][i] + (psi*psi')/length(s[3])/norm(psi)^2
+            i = i + 1
+        end
+    end
+end
+
+Base.done(p::SampleProc, cfg, s) = nothing
+
+# Creating the array of methods on which benchmarks have to be performed
+procs = Proc[ SampleProc{QuMCWF}()]
+
+# Setting up various configurations.
+cfgs = JaynesCummings[JaynesCummings(2, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, true, 200, 0.:0.1:2*pi),
+                      JaynesCummings(3, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, true, 300, 0.:0.1:2*pi),
+                      JaynesCummings(6, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, true, 400, 0.:0.1:2*pi),
+                      JaynesCummings(10, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, true, 500, 0.:0.1:2*pi),
+                      JaynesCummings(2, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, false, 200, 0.:0.1:2*pi),
+                      JaynesCummings(3, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, false, 300, 0.:0.1:2*pi),
+                      JaynesCummings(6, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, false, 400, 0.:0.1:2*pi),
+                      JaynesCummings(10, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, false, 500, 0.:0.1:2*pi),
+                      JaynesCummings(2, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, true, 200, 0.0:0.20134228187919462:30.0),
+                      JaynesCummings(3, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, true, 300, 0.0:0.20134228187919462:30.0),
+                      JaynesCummings(6, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, true, 400, 0.0:0.20134228187919462:30.0),
+                      JaynesCummings(10, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, true, 500, 0.0:0.20134228187919462:30.0),
+                      JaynesCummings(2, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, false, 200, 0.0:0.20134228187919462:30.0),
+                      JaynesCummings(3, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, false, 300, 0.0:0.20134228187919462:30.0),
+                      JaynesCummings(6, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, false, 400, 0.0:0.20134228187919462:30.0),
+                      JaynesCummings(10, 1.0 * 2 * pi, 1.0 * 2 * pi, 0.05 * 2 * pi, 0.05, 0.15, false, 500, 0.0:0.20134228187919462:30.0)]
+
+# Generating the timing analysis.
+rtable = run(procs, cfgs)
+
+# Table display from the above method.
+show(rtable; unit=:usec)

--- a/src/propmachinery.jl
+++ b/src/propmachinery.jl
@@ -47,7 +47,8 @@ QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix}(eq::QuLin
 
 QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix, COT<:QuBase.AbstractQuMatrix}(hamiltonian::QuBase.AbstractQuMatrix, collapse_ops::Vector{COT}, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLindbladMasterEq}(QuLindbladMasterEq(hamiltonian,collapse_ops), init_state, tlist, method)
 
-QuStateEvolution{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector, COT<:QuBase.AbstractQuMatrix}(hamiltonian::QuBase.AbstractQuMatrix, collapse_ops::Vector{COT}, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QuLindbladMasterEq}(QuLindbladMasterEq(hamiltonian,collapse_ops), init_state, tlist, method)
+# QuLindbladMasterEqUncached is used as the construction of Lindblad operator is not required for every tracjectory.
+QuStateEvolution{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector, COT<:QuBase.AbstractQuMatrix}(hamiltonian::QuBase.AbstractQuMatrix, collapse_ops::Vector{COT}, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QuLindbladMasterEq}(QuLindbladMasterEqUncached(hamiltonian,collapse_ops), init_state, tlist, method)
 
 # QuPropagator and QuStateEvolution types are the same.
 typealias QuPropagator QuStateEvolution

--- a/test/propagatortest.jl
+++ b/test/propagatortest.jl
@@ -125,7 +125,7 @@ for (t, rhot) in prop_expm
     j = j + 1
 end
 
-ind = findin(tlist, rand(tlist))[1]
+ind=rand(1:(length(tlist)-1))
 @test_approx_eq_eps coeffs(vec(rhos[ind])) coeffs(vec(ps[ind])) 1e-1
 
 # tests for  evolution opeator.
@@ -133,3 +133,7 @@ evolved_state = coeffs(propagate(QuExpokit(), QuSchrodingerEq(hamiltonian), tlis
 @test_approx_eq coeffs(QuEvolutionOp(sigmax, 0.1)*init_state) evolved_state
 @test_approx_eq coeffs(QuEvolutionOp(sigmax, tlist[5], tlist[4])*init_state) evolved_state
 @test_approx_eq coeffs(QuEvolutionOp(QuSchrodingerEq(sigmax), tlist[5], tlist[4])*init_state) evolved_state
+
+# caching and uncached version testing
+@assert QuLindbladMasterEqUncached(sigmax, [sigmax]).lindblad == nothing
+@assert QuLindbladMasterEq(sigmax, [sigmax]).lindblad == QuDynamics.operator(QuLindbladMasterEqUncached(sigmax,  [sigmax]))


### PR DESCRIPTION
Flag has been passed through `QuEquation` and this has been used to cache the lindblad operator construct. Also for `MCWF` construct uncached version has been used as we do not need the lindblad operator construct. 
