### PR TITLE
Travis integration allowed to fail on latest build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,7 @@ script:
     - julia -e 'Pkg.clone("https://github.com/marcusps/ExpmV.jl.git")';
     - julia -e 'Pkg.clone("https://github.com/acroy/Expokit.jl.git")';
     - julia -e 'Pkg.clone(pwd()); Pkg.build("QuDynamics"); Pkg.test("QuDynamics")';
+matrix:
+  allow_failures: # import normalize in QuBase as this is in Base in v 0.5.
+    - julia: nightly
+  fast_finish: true


### PR DESCRIPTION
Travis integration fails on the nightly build. I guess the failure is because of `normalize!` being included in the base(the fix however lies in `QuBase`). As everything works fine on release version, build constraints are changed such that a failure is allowed on nightly build. 
