### PR TITLE
Addition of ProgressMeter using ProgressMeter.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.3
 Compat
 Docile
 ODE 0.2.1
+ProgressMeter

--- a/src/propmachinery.jl
+++ b/src/propmachinery.jl
@@ -223,6 +223,28 @@ macro showprogress_expectation(qprop, expectation_operators)
     end
 end
 
+function Base.show(io::IO, qprop::QuPropagator)
+    field_params = fieldnames(qprop.eq)
+    println(io, "Summarizing the system :")
+    if :lindblad in field_params && :hamiltonian in field_params
+        println(io, "Equation type : $(typeof(qprop.eq))")
+        println(io, "Size of the Lindblad operator of the system : $(size(coeffs(qprop.eq.lindblad)))")
+        println(io, "Size of the Hamiltonian of the system : $(size(coeffs(qprop.eq.hamiltonian)))")
+        println(io, "Number of collapse operators : $(length(qprop.eq.collapse_ops))")
+        println(io, "Size of the Density matrix : $(size(coeffs(qprop.init_state)))")
+    elseif :hamiltonian in field_params
+        println(io, "Equation type : $(typeof(qprop.eq))")
+        println(io, "Size of the Hamiltonian of the system : $(size(coeffs(qprop.eq.hamiltonian)))")
+        println(io, "Size of the Initial state : $(size(coeffs(qprop.init_state)))")
+    elseif :liouvillian in field_params
+        println(io, "Equation type : $(typeof(qprop.eq))")
+        println(io, "Size of the Liouvillian of the system : $(size(coeffs(qprop.eq.liouvillian)))")
+        println(io, "Size of the Density matrix : $(size(coeffs(qprop.init_state)))")
+    end
+    println(io, "Time steps used : $(qprop.tlist)")
+    println(io, "Solver used : $(qprop.method)")
+end
+
 export  QuStateEvolution,
       QuPropagator,
       QuEvolutionOp,


### PR DESCRIPTION
Adding the macros :

`@showprogress`, `@showprogress_trace`, `@showprogress_expectation` which return the evolved states, trace of the evolved states, expectation values with respect to expectation operators. The first two accept `QuPropagator` as parameter, while the last requires the expectation operators. 

But this does not work : 

``` julia
julia> qpro = QuPropagator(sigmax+2*sigmay+3*sigmaz, [lowerop(2)*sqrt(3), raiseop(2)*sqrt(2)], statevec(1, FiniteBasis(2))*statevec(1, FiniteBasis(2))', 0.:0.1:24000, QuExpmV())

julia> @showprogress qpro
ERROR: UndefVarError: qpro not defined
```
