### PR TITLE
QuBase independent and sparse support.

### DIFF
--- a/src/QuDynamics.jl
+++ b/src/QuDynamics.jl
@@ -1,5 +1,5 @@
 module QuDynamics
-    using QuBase
+    # using QuBase
     using Compat
     using ODE
     using Expokit
@@ -11,10 +11,10 @@ module QuDynamics
     include("propodesolvers.jl")
     include("propexpmsolvers.jl")
     include("propmcwf.jl")
-    module QuTiP
-    using ..QuBase
-    using ..QuDynamics
-    include("qutipinterface.jl")
-    end
+    # module QuTiP
+    # using ..QuBase
+    # using ..QuDynamics
+    # include("qutipinterface.jl")
+    # end
     export propagate
 end

--- a/src/propexpmsolvers.jl
+++ b/src/propexpmsolvers.jl
@@ -39,18 +39,16 @@ QuExpmV() = QuExpmV(Dict())
 function propagate(prob::QuExpokit, eq::QuEquation, t, current_t, current_qustate)
     dt = t - current_t
     dims = size(current_qustate)
-    next_state = Expokit.expmv(dt, -im*coeffs(operator(eq, t)), coeffs(vec(current_qustate)), m = get(prob.options, :m, 30), tol = get(prob.options, :tol, 1e-7))
-    CQST = QuBase.similar_type(current_qustate)
-    return CQST(reshape(next_state, dims), bases(current_qustate))
+    next_state = Expokit.expmv(dt, -im*operator(eq, t), vec(current_qustate), m = get(prob.options, :m, 30), tol = get(prob.options, :tol, 1e-7))
+    return reshape(next_state, dims)
 end
 
 function propagate(prob::QuExpmV, eq::QuEquation, t, current_t, current_qustate)
     dt = t - current_t
     dims = size(current_qustate)
-    next_state = ExpmV.expmv(dt, -im*coeffs(operator(eq, t)), coeffs(vec(current_qustate)), M = get(prob.options, :M, []), prec = get(prob.options, :prec, "double"),
+    next_state = ExpmV.expmv(dt, -im*operator(eq, t), vec(current_qustate), M = get(prob.options, :M, []), prec = get(prob.options, :prec, "double"),
                             shift = get(prob.options, :shift, false), full_term = get(prob.options, :full_term, false))
-    CQST = QuBase.similar_type(current_qustate)
-    return CQST(reshape(next_state, dims), bases(current_qustate))
+    return reshape(next_state, dims)
 end
 
 export QuExpokit,

--- a/src/propmachinery.jl
+++ b/src/propmachinery.jl
@@ -27,7 +27,7 @@ Inputs :
 Output :
 * QuPropagator construct depending on the input.
 """ ->
-immutable QuStateEvolution{QPM<:QuPropagatorMethod, QVM<:@compat(Union{QuBase.AbstractQuVector,QuBase.AbstractQuMatrix}), QE<:QuEquation}
+immutable QuStateEvolution{QPM<:QuPropagatorMethod, QVM<:@compat(Union{AbstractVector, AbstractMatrix, SparseVector, SparseMatrixCSC}), QE<:QuEquation}
     eq::QE
     init_state::QVM
     tlist
@@ -35,24 +35,57 @@ immutable QuStateEvolution{QPM<:QuPropagatorMethod, QVM<:@compat(Union{QuBase.Ab
     QuStateEvolution(eq, init_state, tlist, method) = new(eq, init_state, tlist, method)
 end
 
-QuStateEvolution{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector, QE<: QuEquation}(eq::QE, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QE}(eq, init_state, tlist, method)
+# QuStateEvolution{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector, QE<: QuEquation}(eq::QE, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QE}(eq, init_state, tlist, method)
 
-QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix, QE<: QuEquation}(eq::QE, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QE}(eq, init_state, tlist, method)
+QuStateEvolution{QPM<:QuPropagatorMethod, QV<:Union{AbstractVector, SparseVector}, QE<: QuEquation}(eq::QE, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QE}(eq, init_state, tlist, method)
 
-QuStateEvolution{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector}(eq::QuSchrodingerEq, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QuSchrodingerEq}(eq, init_state, tlist, method)
+# QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix, QE<: QuEquation}(eq::QE, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QE}(eq, init_state, tlist, method)
 
-QuStateEvolution{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector}(hamiltonian::QuBase.AbstractQuMatrix, init_state::QV,  tlist, method::QPM) = QuStateEvolution{QPM,QV,QuSchrodingerEq}(QuSchrodingerEq(hamiltonian),init_state, tlist, method)
+QuStateEvolution{QPM<:QuPropagatorMethod, QM<:Union{AbstractMatrix, SparseMatrixCSC}, QE<: QuEquation}(eq::QE, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QE}(eq, init_state, tlist, method)
 
-QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix}(eq::QuLiouvillevonNeumannEq, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLiouvillevonNeumannEq}(eq, init_state, tlist, method)
+# QuStateEvolution{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector}(eq::QuSchrodingerEq, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QuSchrodingerEq}(eq, init_state, tlist, method)
 
-QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix}(hamiltonian::QuBase.AbstractQuMatrix, init_state::QM,  tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLiouvillevonNeumannEq}(QuLiouvillevonNeumannEq(liouvillian_op(hamiltonian)),init_state, tlist, method)
+QuStateEvolution{QPM<:QuPropagatorMethod, QV<:AbstractVector}(eq::QuSchrodingerEq, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QuSchrodingerEq}(eq, init_state, tlist, method)
 
-QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix}(eq::QuLindbladMasterEq, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLindbladMasterEq}(eq, init_state, tlist, method)
+QuStateEvolution{QPM<:QuPropagatorMethod, QV<:SparseVector}(eq::QuSchrodingerEqSparse, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QuSchrodingerEqSparse}(eq, SparseMatrixCSC(init_state), tlist, method)
 
-QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix, COT<:QuBase.AbstractQuMatrix}(hamiltonian::QuBase.AbstractQuMatrix, collapse_ops::Vector{COT}, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLindbladMasterEq}(QuLindbladMasterEq(hamiltonian,collapse_ops), init_state, tlist, method)
+# QuStateEvolution{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector}(hamiltonian::QuBase.AbstractQuMatrix, init_state::QV,  tlist, method::QPM) = QuStateEvolution{QPM,QV,QuSchrodingerEq}(QuSchrodingerEq(hamiltonian),init_state, tlist, method)
+
+QuStateEvolution{QPM<:QuPropagatorMethod, QV<:AbstractVector}(hamiltonian::AbstractMatrix, init_state::QV,  tlist, method::QPM) = QuStateEvolution{QPM,QV,QuSchrodingerEq}(QuSchrodingerEq(hamiltonian),init_state, tlist, method)
+
+QuStateEvolution{QPM<:QuPropagatorMethod, QV<:SparseVector}(hamiltonian::SparseMatrixCSC, init_state::QV,  tlist, method::QPM) = QuStateEvolution{QPM,QV,QuSchrodingerEqSparse}(QuSchrodingerEqSparse(hamiltonian), SparseMatrixCSC(init_state), tlist, method)
+
+# QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix}(eq::QuLiouvillevonNeumannEq, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLiouvillevonNeumannEq}(eq, init_state, tlist, method)
+
+QuStateEvolution{QPM<:QuPropagatorMethod, QM<:AbstractMatrix}(eq::QuLiouvillevonNeumannEq, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLiouvillevonNeumannEq}(eq, init_state, tlist, method)
+
+QuStateEvolution{QPM<:QuPropagatorMethod, QM<:SparseMatrixCSC}(eq::QuLiouvillevonNeumannEqSparse, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLiouvillevonNeumannEqSparse}(eq, init_state, tlist, method)
+
+# QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix}(hamiltonian::QuBase.AbstractQuMatrix, init_state::QM,  tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLiouvillevonNeumannEq}(QuLiouvillevonNeumannEq(liouvillian_op(hamiltonian)),init_state, tlist, method)
+
+QuStateEvolution{QPM<:QuPropagatorMethod, QM<:AbstractMatrix}(hamiltonian::AbstractMatrix, init_state::QM,  tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLiouvillevonNeumannEq}(QuLiouvillevonNeumannEq(liouvillian_op(hamiltonian)),init_state, tlist, method)
+
+QuStateEvolution{QPM<:QuPropagatorMethod, QM<:SparseMatrixCSC}(hamiltonian::SparseMatrixCSC, init_state::QM,  tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLiouvillevonNeumannEqSparse}(QuLiouvillevonNeumannEqSparse(liouvillian_op(hamiltonian)),init_state, tlist, method)
+
+# QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix}(eq::QuLindbladMasterEq, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLindbladMasterEq}(eq, init_state, tlist, method)
+
+QuStateEvolution{QPM<:QuPropagatorMethod, QM<:AbstractMatrix}(eq::QuLindbladMasterEq, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLindbladMasterEq}(eq, init_state, tlist, method)
+
+QuStateEvolution{QPM<:QuPropagatorMethod, QM<:SparseMatrixCSC}(eq::QuLindbladMasterEqSparse, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLindbladMasterEqSparse}(eq, init_state, tlist, method)
+
+
+# QuStateEvolution{QPM<:QuPropagatorMethod, QM<:QuBase.AbstractQuMatrix, COT<:QuBase.AbstractQuMatrix}(hamiltonian::QuBase.AbstractQuMatrix, collapse_ops::Vector{COT}, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLindbladMasterEq}(QuLindbladMasterEq(hamiltonian,collapse_ops), init_state, tlist, method)
+
+QuStateEvolution{QPM<:QuPropagatorMethod, QM<:AbstractMatrix, COT<:AbstractMatrix}(hamiltonian::AbstractMatrix, collapse_ops::Vector{COT}, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLindbladMasterEq}(QuLindbladMasterEq(hamiltonian,collapse_ops), init_state, tlist, method)
+
+QuStateEvolution{QPM<:QuPropagatorMethod, QM<:SparseMatrixCSC, COT<:SparseMatrixCSC}(hamiltonian::SparseMatrixCSC, collapse_ops::Vector{COT}, init_state::QM, tlist, method::QPM) = QuStateEvolution{QPM,QM,QuLindbladMasterEqSparse}(QuLindbladMasterEqSparse(hamiltonian,collapse_ops), init_state, tlist, method)
 
 # QuLindbladMasterEqUncached is used as the construction of Lindblad operator is not required for every tracjectory.
-QuStateEvolution{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector, COT<:QuBase.AbstractQuMatrix}(hamiltonian::QuBase.AbstractQuMatrix, collapse_ops::Vector{COT}, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QuLindbladMasterEq}(QuLindbladMasterEqUncached(hamiltonian,collapse_ops), init_state, tlist, method)
+# QuStateEvolution{QPM<:QuPropagatorMethod, QV<:QuBase.AbstractQuVector, COT<:QuBase.AbstractQuMatrix}(hamiltonian::QuBase.AbstractQuMatrix, collapse_ops::Vector{COT}, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QuLindbladMasterEq}(QuLindbladMasterEqUncached(hamiltonian,collapse_ops), init_state, tlist, method)
+
+QuStateEvolution{QPM<:QuPropagatorMethod, QV<:AbstractVector, COT<:AbstractMatrix}(hamiltonian::AbstractMatrix, collapse_ops::Vector{COT}, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QuLindbladMasterEq}(QuLindbladMasterEqUncached(hamiltonian,collapse_ops), init_state, tlist, method)
+
+QuStateEvolution{QPM<:QuPropagatorMethod, QV<:SparseVector, COT<:SparseMatrixCSC}(hamiltonian::SparseMatrixCSC, collapse_ops::Vector{COT}, init_state::QV, tlist, method::QPM) = QuStateEvolution{QPM,QV,QuLindbladMasterEqSparse}(QuLindbladMasterEqUncachedSparse(hamiltonian,collapse_ops), SparseMatrixCSC(init_state), tlist, method)
 
 # QuPropagator and QuStateEvolution types are the same.
 typealias QuPropagator QuStateEvolution
@@ -169,9 +202,13 @@ Inputs :
 Output :
 * Evolved operator.
 """ ->
-QuEvolutionOp{QM<:QuBase.AbstractQuMatrix}(op::QM, dt::Float64) = expm(-im*op*dt)
+QuEvolutionOp{QM<:AbstractMatrix}(op::QM, dt::Float64) = expm(-im*op*dt)
 
-QuEvolutionOp{QM<:QuBase.AbstractQuMatrix}(op::QM, tf::Float64,  ti::Float64) = QuEvolutionOp(op, tf-ti)
+QuEvolutionOp{QM<:SparseMatrixCSC}(op::QM, dt::Float64) = expm(-im*op*dt)
+
+QuEvolutionOp{QM<:AbstractMatrix}(op::QM, tf::Float64,  ti::Float64) = QuEvolutionOp(op, tf-ti)
+
+QuEvolutionOp{QM<:SparseMatrixCSC}(op::QM, tf::Float64,  ti::Float64) = QuEvolutionOp(op, tf-ti)
 
 QuEvolutionOp{QE<:QuEquation}(eq::QE, dt::Float64) = QuEvolutionOp(operator(eq), dt)
 
@@ -182,18 +219,18 @@ function Base.show(io::IO, qprop::QuPropagator)
     println(io, "Summarizing the system :")
     if :lindblad in field_params && :hamiltonian in field_params
         println(io, "Equation type : $(typeof(qprop.eq))")
-        println(io, "Size of the Lindblad operator of the system : $(size(coeffs(qprop.eq.lindblad)))")
-        println(io, "Size of the Hamiltonian of the system : $(size(coeffs(qprop.eq.hamiltonian)))")
+        println(io, "Size of the Lindblad operator of the system : $(size(qprop.eq.lindblad))")
+        println(io, "Size of the Hamiltonian of the system : $(size(qprop.eq.hamiltonian))")
         println(io, "Number of collapse operators : $(length(qprop.eq.collapse_ops))")
-        println(io, "Size of the Density matrix : $(size(coeffs(qprop.init_state)))")
+        println(io, "Size of the Density matrix : $(size(qprop.init_state))")
     elseif :hamiltonian in field_params
         println(io, "Equation type : $(typeof(qprop.eq))")
-        println(io, "Size of the Hamiltonian of the system : $(size(coeffs(qprop.eq.hamiltonian)))")
-        println(io, "Size of the Initial state : $(size(coeffs(qprop.init_state)))")
+        println(io, "Size of the Hamiltonian of the system : $(size(qprop.eq.hamiltonian))")
+        println(io, "Size of the Initial state : $(size(qprop.init_state))")
     elseif :liouvillian in field_params
         println(io, "Equation type : $(typeof(qprop.eq))")
-        println(io, "Size of the Liouvillian of the system : $(size(coeffs(qprop.eq.liouvillian)))")
-        println(io, "Size of the Density matrix : $(size(coeffs(qprop.init_state)))")
+        println(io, "Size of the Liouvillian of the system : $(size(qprop.eq.liouvillian))")
+        println(io, "Size of the Density matrix : $(size(qprop.init_state))")
     end
     println(io, "Time steps used : $(qprop.tlist)")
     println(io, "Solver used : $(qprop.method)")

--- a/src/propodesolvers.jl
+++ b/src/propodesolvers.jl
@@ -31,10 +31,9 @@ for (qu_ode_type,ode_solver) in type_to_method_ode
             dims = size(current_qustate)
             # Convert the current_qustate to complex as it might result in a Inexact Error. After complex is in QuBase.jl (PR #38)
             # we could just do a complex(vec(current_qustate)) avoiding the coeffs(coeffs(vec(current_qustate))).
-            next_state = $ode_solver((t,y)-> -im*coeffs(op)*y, complex(coeffs(vec(current_qustate))), [current_t, t], points=:specified,
+            next_state = $ode_solver((t,y)-> -im*op*y, complex(vec(current_qustate)), [current_t, t], points=:specified,
                                   reltol = get(prob.options, :reltol, 1.0e-5), abstol = get(prob.options, :abstol, 1.0e-8))[2][end]
-            CQST = QuBase.similar_type(current_qustate)
-            return CQST(reshape(next_state, dims), bases(current_qustate))
+            return reshape(next_state, dims)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,4 +4,4 @@ using Base.Test
 using Compat
 
 include("propagatortest.jl")
-include("qutipinterfacetest.jl")
+# include("qutipinterfacetest.jl")


### PR DESCRIPTION
Most of the current functionality gets broken. Specially the ODE solvers. Sparse support is aimed at and QuBase arrays are replaced by `AbstractVector`, `AbstractMatrix`, `SparseVector`, `SparseMatrixCSC` as required with creation of new types. 